### PR TITLE
Update PHP package names for PHP 5.6

### DIFF
--- a/setup-drupalvm.sh
+++ b/setup-drupalvm.sh
@@ -161,32 +161,38 @@ YML
 
 if [ "$php_version" != "7.0" ]; then
   cat >> config.yml <<- PHPSETTINGS
+php_install_recommends: no
 php_packages:
-  - php5
-  - php5-apcu
-  - php5-mcrypt
-  - php5-cli
-  - php5-common
-  - php5-curl
-  - php5-dev
-  - php5-fpm
-  - php5-gd
-  - php5-sqlite
+  - php5.6
+  - php5.6-apcu
+  - php5.6-mcrypt
+  - php5.6-cli
+  - php5.6-common
+  - php5.6-curl
+  - php5.6-dev
+  - php5.6-fpm
+  - php5.6-gd
+  - php5.6-sqlite3
+  - php5.6-xml
+  - php5.6-mbstring
   - php-pear
   - libpcre3-dev
 php_conf_paths:
-  - /etc/php5/fpm
-  - /etc/php5/apache2
-  - /etc/php5/cli
+  - /etc/php/5.6/fpm
+  - /etc/php/5.6/apache2
+  - /etc/php/5.6/cli
 php_extension_conf_paths:
-  - /etc/php5/fpm/conf.d
-  - /etc/php5/apache2/conf.d
-  - /etc/php5/cli/conf.d
-php_fpm_daemon: php5-fpm
-php_fpm_conf_path: "/etc/php5/fpm"
-php_fpm_pool_conf_path: "/etc/php5/fpm/pool.d/www.conf"
-php_mysql_package: php5-mysql
-php_memcached_package: php5-memcached
+  - /etc/php/5.6/fpm/conf.d
+  - /etc/php/5.6/apache2/conf.d
+  - /etc/php/5.6/cli/conf.d
+php_fpm_daemon: php5.6-fpm
+php_fpm_conf_path: "/etc/php/5.6/fpm"
+php_fpm_pool_conf_path: "/etc/php/5.6/fpm/pool.d/www.conf"
+php_mysql_package: php5.6-mysql
+php_memcached_package: php5.6-memcached
+php_redis_package: php5.6-redis
+xhprof_download_url: https://github.com/phacility/xhprof/archive/master.tar.gz
+xhprof_download_folder_name: xhprof-master
 PHPSETTINGS
 fi
 


### PR DESCRIPTION
Resolves #3 

Package names taken from http://docs.drupalvm.com/en/latest/other/php-56/